### PR TITLE
Docs: add authentication setup via Streamlit Secrets/env

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ streamlit run streamlit_app.py
 
 The dashboard will open in your default web browser at `http://localhost:8501`
 
+### 🔐 Configure Authentication (recommended)
+
+This app supports simple authentication. In Streamlit Cloud, set the following secrets (App → Settings → Secrets):
+
+```
+app_user: admin
+app_password: ppmi2025
+```
+
+For local development, you can alternatively use environment variables:
+
+```bash
+export APP_USER=admin
+export APP_PASSWORD=ppmi2025
+streamlit run streamlit_app.py
+```
+
+If no secrets or env vars are provided, the app falls back to the default credentials shown above and displays a hint on the login screen.
+
 ## Usage Guide
 
 ### Getting Started

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,6 +3,7 @@ import pandas as pd
 import plotly.express as px
 from data_loader import PPMIDataLoader
 import numpy as np
+import os
 
 # --- Page Configuration ---
 st.set_page_config(
@@ -13,9 +14,12 @@ st.set_page_config(
 )
 
 # --- Authentication ---
-# Suggested credentials: Username: admin / Password: ppmi2025
-DEFAULT_USERNAME = "admin"
-DEFAULT_PASSWORD = "ppmi2025"
+# Credentials are sourced from Streamlit Secrets if available, with env vars as fallback.
+# Define in Streamlit Cloud → App → Settings → Secrets:
+#   app_user: your_username
+#   app_password: your_password
+DEFAULT_USERNAME = st.secrets.get("app_user", os.getenv("APP_USER", "admin"))
+DEFAULT_PASSWORD = st.secrets.get("app_password", os.getenv("APP_PASSWORD", "ppmi2025"))
 
 def check_password():
     """Returns `True` if the user has entered the correct password."""
@@ -38,8 +42,11 @@ def login_form():
         st.text_input("Username", key="username")
         st.text_input("Password", type="password", key="password")
         st.form_submit_button("Log in", on_click=check_password)
-    
-    st.info("💡 Default credentials: Username: `admin` / Password: `ppmi2025`")
+
+    # Only display default hint when not using Secrets or env overrides
+    if ("app_user" not in st.secrets and "app_password" not in st.secrets
+        and os.getenv("APP_USER") is None and os.getenv("APP_PASSWORD") is None):
+        st.info("💡 Default credentials: Username: `admin` / Password: `ppmi2025`")
 
 # --- Custom CSS ---
 st.markdown("""


### PR DESCRIPTION
Adds a short section to README describing how to configure authentication using Streamlit Secrets (, ) and local env vars (, ).