### PR TITLE
Add Project 177 + All-biomarkers selection in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ streamlit run streamlit_app.py
 
 The dashboard will open in your default web browser at `http://localhost:8501`
 
+### 🔐 Configure Authentication (recommended)
+
+This app supports simple authentication. In Streamlit Cloud, set the following secrets (App → Settings → Secrets):
+
+```
+app_user: admin
+app_password: ppmi2025
+```
+
+For local development, you can alternatively use environment variables:
+
+```bash
+export APP_USER=admin
+export APP_PASSWORD=ppmi2025
+streamlit run streamlit_app.py
+```
+
+If no secrets or env vars are provided, the app falls back to the default credentials shown above and displays a hint on the login screen.
+
 ## Usage Guide
 
 ### Getting Started

--- a/data_loader.py
+++ b/data_loader.py
@@ -68,7 +68,7 @@ class PPMIDataLoader:
         # Filter for key biomarkers and focus projects
         pd_pros_proteins = ['NEFL', 'TIMP1', 'A2M', 'VCAM1', 'GFAP', 'IL6R', 'ENRAGE', 'VEGFA', 'DCN', 'MMP2', 'GP130', 'FGF21', 'UCHL1', 'ICAM1']
         biomarker_keywords = ['synuclein', 'tau', 'p-tau', 'ptau', 'alpha', 'aSyn', 'amyloid', 'abeta'] + pd_pros_proteins
-        focus_projects = [124, 125, 159, 172, 173, 207]
+        focus_projects = [124, 125, 159, 172, 173, 177, 207]
         
         # Focus on key biomarkers OR focus projects
         key_biomarkers = self.biomarker_data[

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,6 +3,7 @@ import pandas as pd
 import plotly.express as px
 from data_loader import PPMIDataLoader
 import numpy as np
+import os
 
 # --- Page Configuration ---
 st.set_page_config(
@@ -13,9 +14,12 @@ st.set_page_config(
 )
 
 # --- Authentication ---
-# Suggested credentials: Username: admin / Password: ppmi2025
-DEFAULT_USERNAME = "admin"
-DEFAULT_PASSWORD = "ppmi2025"
+# Credentials are sourced from Streamlit Secrets if available, with env vars as fallback.
+# Define in Streamlit Cloud → App → Settings → Secrets:
+#   app_user: your_username
+#   app_password: your_password
+DEFAULT_USERNAME = st.secrets.get("app_user", os.getenv("APP_USER", "admin"))
+DEFAULT_PASSWORD = st.secrets.get("app_password", os.getenv("APP_PASSWORD", "ppmi2025"))
 
 def check_password():
     """Returns `True` if the user has entered the correct password."""
@@ -38,8 +42,11 @@ def login_form():
         st.text_input("Username", key="username")
         st.text_input("Password", type="password", key="password")
         st.form_submit_button("Log in", on_click=check_password)
-    
-    st.info("💡 Default credentials: Username: `admin` / Password: `ppmi2025`")
+
+    # Only display default hint when not using Secrets or env overrides
+    if ("app_user" not in st.secrets and "app_password" not in st.secrets
+        and os.getenv("APP_USER") is None and os.getenv("APP_PASSWORD") is None):
+        st.info("💡 Default credentials: Username: `admin` / Password: `ppmi2025`")
 
 # --- Custom CSS ---
 st.markdown("""


### PR DESCRIPTION
- Include Project 177 in focus_projects so its assays are loaded even when names don’t match keywords.
- Add sidebar toggle to choose between Key biomarkers and All available biomarkers for selection in Distribution/Longitudinal/Correlation tabs.
- Guard defaults in correlation tab when fewer than two biomarkers are available.

This enables exploring Project 177 biomarkers immediately without hardcoding their names.