### PR TITLE
Default Project filter to 177

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -147,7 +147,12 @@ def show_dashboard_page():
         selected_risk = []
 
     project_options = sorted(data['PROJECTID'].dropna().unique())
-    selected_projects = st.sidebar.multiselect("Filter by Project ID", project_options, default=list(project_options))
+    default_projects = [177] if 177 in project_options else project_options
+    selected_projects = st.sidebar.multiselect(
+        "Filter by Project ID",
+        project_options,
+        default=default_projects
+    )
 
     # Apply filters
     filtered_data = data[


### PR DESCRIPTION
- Default the Project ID sidebar filter to 177 when present, while keeping multiselect so other projects can be added.
- Continues to allow selecting additional projects; if 177 is absent, defaults to all projects.

Context: requested to focus dashboard initially on Project 177 without removing access to others.